### PR TITLE
Enable GPU usage for eval script

### DIFF
--- a/eval.py
+++ b/eval.py
@@ -6,6 +6,7 @@ from constants import SUPPORTED_METRICS, CORPORA, LLAMA_DIR, DEFAULT_DATA, AUC_R
 
 import os
 from transformers import LlamaForCausalLM, LlamaTokenizer
+import torch
 from typing import List, Dict, Literal
 from pandas import DataFrame
 
@@ -29,6 +30,7 @@ def eval_model(
     knowmem_retain_qa_file: str | None = None,
     knowmem_retain_qa_icl_file: str | None = None,
     temp_dir: str | None = None,
+    device: str | None = None,
 ) -> Dict[str, float]:
     # Argument sanity check
     if not metrics:
@@ -38,6 +40,9 @@ def eval_model(
             raise ValueError(f"Given metric {metric} is not supported.")
     if corpus is not None and corpus not in CORPORA:
         raise ValueError(f"Invalid corpus. `corpus` should be either 'news' or 'books'.")
+    if device is None:
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+    model = model.to(device)
     if corpus is not None:
         verbmem_forget_file = DEFAULT_DATA[corpus]['verbmem_forget_file'] if verbmem_forget_file is None else verbmem_forget_file
         privleak_forget_file = DEFAULT_DATA[corpus]['privleak_forget_file'] if privleak_forget_file is None else privleak_forget_file
@@ -145,7 +150,8 @@ def load_then_eval_models(
     tokenizer_dir: str = LLAMA_DIR,
     out_file: str | None = None,
     metrics: List[str] = SUPPORTED_METRICS,
-    temp_dir: str = "temp"
+    temp_dir: str = "temp",
+    device: str | None = None,
 ) -> DataFrame:
     # Argument sanity check
     # if not model_dirs:
@@ -163,16 +169,20 @@ def load_then_eval_models(
     if out_file is not None and not out_file.endswith('.csv'):
         raise ValueError(f"The file extension of `out_file` should be '.csv'.")
 
+    if device is None:
+        device = 'cuda' if torch.cuda.is_available() else 'cpu'
+
     # Run evaluation
     out = []
     print(out_file)
     for model_dir, name in zip(model_dirs, names):
         print(f"Evaluating model {name} at {model_dir} ...")
-        model = load_model(model_dir)
+        model = load_model(model_dir).to(device)
         tokenizer = load_tokenizer(tokenizer_dir)
         res = eval_model(
             model, tokenizer, metrics, corpus,
-            temp_dir=os.path.join(temp_dir, name)
+            temp_dir=os.path.join(temp_dir, name),
+            device=device
         )
         out.append({'name': name} | res)
         print(out)
@@ -192,6 +202,8 @@ if __name__ == '__main__':
     parser.add_argument('--corpus', type=str, required=True, choices=CORPORA)
     parser.add_argument('--out_file', type=str, required=True)
     parser.add_argument('--metrics', type=str, nargs='+', default=SUPPORTED_METRICS)
+    parser.add_argument('--device', type=str, default=None,
+                        help="Device to run evaluation on (e.g., 'cuda' or 'cpu'). Defaults to CUDA if available.")
     args = parser.parse_args()
     args_dict = vars(args)
     load_then_eval_models(**args_dict)


### PR DESCRIPTION
## Summary
- add `device` option to evaluation workflow
- move models to GPU if available

## Testing
- `python -m py_compile eval.py`
- `python eval.py --help | head`

------
https://chatgpt.com/codex/tasks/task_e_6875ec8005e483268db1c0231f68f788