### PR TITLE
Add upsampling support to unlearning dataset

### DIFF
--- a/baselines/baselines/dataset.py
+++ b/baselines/baselines/dataset.py
@@ -69,7 +69,8 @@ class DefaultDataset(Dataset):
         # forget_subset_indices: list[int] | None = None,
         portion: float = 1.0,
         exclude_file: str | None = None,
-        rand_seed: int = 1
+        rand_seed: int = 1,
+        upsampling: int = 1
     ):
         if Path(file_path).suffix == '.json':
             with open(file_path, 'r') as f:
@@ -168,7 +169,11 @@ class DefaultDataset(Dataset):
                 writer = csv.writer(csvfile)
                 writer.writerow(["id"])
                 for idx in forget_subset_indices:
-                    writer.writerow([idx]) 
+                    writer.writerow([idx])
+
+        if upsampling > 1:
+            self.input_ids = self.input_ids * int(upsampling)
+            print(f"Upsampled forget set by a factor of {upsampling}. New length: {len(self.input_ids)}")
 
         # Original strings
         self.strings = tokenizer.batch_decode(self.input_ids, skip_special_tokens=True)
@@ -208,11 +213,12 @@ class ForgetRetainDataset(DefaultDataset):
         # forget_subset_indices: list[int] | None = None
         portion: float = 1.0,
         exclude_file: str | None = None,
-        rand_seed: int = 1
+        rand_seed: int = 1,
+        upsampling: int = 1
     ):
         self.forget_dataset = DefaultDataset(
             forget_file_path, tokenizer,
-            max_len=max_len, add_bos_token=add_bos_token, portion=portion, exclude_file=exclude_file, rand_seed=rand_seed # forget_subset_indices=forget_subset_indices
+            max_len=max_len, add_bos_token=add_bos_token, portion=portion, exclude_file=exclude_file, rand_seed=rand_seed, upsampling=upsampling # forget_subset_indices=forget_subset_indices
         )
 
         self.retain_exists = retain_file_path is not None

--- a/baselines/baselines/finetune.py
+++ b/baselines/baselines/finetune.py
@@ -12,7 +12,11 @@ def finetune(
     per_device_batch_size: int = 2,
     learning_rate: float = 1e-5,
     max_len: int = 4096,
-    tokenizer_dir: str | None = None
+    tokenizer_dir: str | None = None,
+    portion: float = 1.0,
+    exclude_file: str | None = None,
+    rand_seed: int = 1,
+    upsampling: int = 1
 ):
     model, tokenizer = load_model_and_tokenizer(
         model_dir,
@@ -22,7 +26,11 @@ def finetune(
     dataset = DefaultDataset(
         data_file,
         tokenizer=tokenizer,
-        max_len=max_len
+        max_len=max_len,
+        portion=portion,
+        exclude_file=exclude_file,
+        rand_seed=rand_seed,
+        upsampling=upsampling
     )
 
     training_args = transformers.TrainingArguments(

--- a/baselines/baselines/iterative.py
+++ b/baselines/baselines/iterative.py
@@ -23,7 +23,8 @@ def unlearn(
     # forget_subset_indices: list[int] | None = None,
     portion: float = 1.0,
     exclude_file: str | None = None,
-    rand_seed: int = 1
+    rand_seed: int = 1,
+    upsampling: int = 1
 ):
     if 'gd' in loss_type:
         assert retain_data_file is not None, "Retain data must be specified for grad_diff."
@@ -60,7 +61,8 @@ def unlearn(
         # forget_subset_indices=forget_subset_indices
         portion=portion,
         exclude_file=exclude_file,
-        rand_seed=rand_seed
+        rand_seed=rand_seed,
+        upsampling=upsampling
     )
 
     if device_count() == 0:

--- a/baselines/unlearn.py
+++ b/baselines/unlearn.py
@@ -41,7 +41,8 @@ def main():
             tokenizer_dir=args.tokenizer_dir,
             portion=args.forget_portion,
             exclude_file=args.match_file,
-            rand_seed=args.seed
+            rand_seed=args.seed,
+            upsampling=args.upsample
         )
         tv_unlearn(
             args.model_dir, args.out_dir,
@@ -64,7 +65,8 @@ def main():
             # forget_subset_indices=forget_subset_indices,
             portion=args.forget_portion,
             exclude_file=args.match_file,
-            rand_seed=args.seed
+            rand_seed=args.seed,
+            upsampling=args.upsample
         )
 
     return;
@@ -111,6 +113,11 @@ def get_args():
     parser.add_argument(
         '--seed', type=int, default=1,
         help="Random seed for reproducibility. Defaults to 1."
+    )
+
+    parser.add_argument(
+        '--upsample', type=int, default=1,
+        help="Upsampling ratio for the forget set."
     )
 
     # Gradient ascent & Gradient difference


### PR DESCRIPTION
## Summary
- allow `DefaultDataset` to repeat the forget set via an `upsampling` parameter
- pass new argument through `ForgetRetainDataset`, `finetune`, `iterative.unlearn`, and CLI
- expose `--upsample` flag in `unlearn.py`

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6880113fda4c8326a9067718c2441cbf